### PR TITLE
Fix IOUtils Py3 compatibility issue

### DIFF
--- a/hyperv/nova/ioutils.py
+++ b/hyperv/nova/ioutils.py
@@ -230,9 +230,7 @@ class IOUtils(object):
         return (ctypes.c_ubyte * buff_size)()
 
     def get_buffer_data(self, buff, num_bytes):
-        data = "".join([struct.pack('B', b)
-                        for b in buff[:num_bytes]])
-        return data
+        return bytes(bytearray(buff[:num_bytes]))
 
     def write_buffer_data(self, buff, data):
         for i, c in enumerate(data):


### PR DESCRIPTION
The method retrieving buffer data was raising a TypeError on Py3.

This patch fixes the issue.

Change-Id: I8a136faaaa7e687c77ae6e2c546617b79889a9b8
